### PR TITLE
Support for Django>=1.7

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
-Unmaintained
-------------
+New maintainer and repo
+-----------------------
 
-This Django app has been without a maintainer since 2011/04. Contact me if you'd like me to point to your fork as the new authoritative repo.
+This repository is out of date. Find the new authoritative repo at https://github.com/RobCombs/django-locking
 
 What the heck is this?
 ----------------------

--- a/README
+++ b/README
@@ -1,3 +1,8 @@
+Unmaintained
+------------
+
+This Django app has been without a maintainer since 2011/04. Contact me if you'd like me to point to your fork as the new authoritative repo.
+
 What the heck is this?
 ----------------------
 


### PR DESCRIPTION
Hi
Currently this package has no support for django>=1.7 there are some changes that needs to make it working in Django>=1.7. 1st thing in urls.py this line needs to be changed from 
from django.conf.urls.defaults import *
to
from django.conf.urls import \* or from django.conf.urls import patterns
2nd thing for django>=1.7
"The module django.utils.simplejson will be removed. The standard library provides json which should be used instead."
this line in views.py
import simplejson to import json also changes in code due to this change.

I have make changes in my branch please review that.
